### PR TITLE
Adds script segment to install input-event-daemon.

### DIFF
--- a/auto-pine/defaults/stage-1/etc/init.d/start_pine_daemons.sh
+++ b/auto-pine/defaults/stage-1/etc/init.d/start_pine_daemons.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Taken from: http://www.debian-administration.org/articles/28
+case "$1" in
+  start)
+    input-event-daemon
+    echo "Running input-event-daemon"
+    ;;
+  stop)
+    echo "TODO: Kill input-event-daemon"
+    ;;
+  *)
+    echo "Usage: sh /etc/init.d/start_pine_daemons.sh {start|stop}"
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/auto-pine/defaults/stage-1/root/setup/pine_setup.sh
+++ b/auto-pine/defaults/stage-1/root/setup/pine_setup.sh
@@ -38,6 +38,18 @@ apt-get --yes --force-yes install curl xorg nodejs openssh-server git-core vim
 # Install rpi-update (https://github.com/Hexxeh/rpi-update/)
 wget http://goo.gl/1BOfJ -O /usr/bin/rpi-update && chmod +x /usr/bin/rpi-update
 
+# Install input-event-daemon
+git clone git://github.com/gandro/input-event-daemon.git /usr/local/lib/input-event-daemon
+cd /usr/local/lib/input-event-daemon
+make
+make install
+
+# TODO: Add actual config settings to this file.  This just creates it so
+# input-event-daemon doesn't error out when run.
+echo \
+"" \
+| cat > /etc/input-event-daemon.conf
+
 
 ####### INSTALL CHROMIUM
 echo

--- a/auto-pine/defaults/stage-1/root/setup/pine_setup.sh
+++ b/auto-pine/defaults/stage-1/root/setup/pine_setup.sh
@@ -114,6 +114,16 @@ cp /etc/inittab /etc/inittab.original
 #sed -i 's/1:2345:respawn:\/sbin\/getty 38400 tty1/#1:2345:respawn:\/sbin\/getty 38400 tty1\n1:2345:respawn:\/bin\/login -f pine-user tty1 <\/dev\/tty1 >\/dev\/tty1 2>\&1/' /etc/inittab
 #perl -pi -e 's/1:2345:respawn:\/sbin\/getty 38400 tty1/#1:2345:respawn:\/sbin\/getty 38400 tty1\n1:2345:respawn:\/bin\/login -f pine-user tty1 <\/dev\/tty1 >\/dev\/tty1 2>\&1/' /etc/inittab
 
+####### INPUT DAEMON
+
+echo
+echo "*** Stage 8 ***"
+echo
+
+cd /etc/init.d/
+chmod 755 start_pine_daemons.sh
+update-rc.d start_pine_daemons.sh defaults
+
 echo
 echo "*** FINISHED***"
 echo "Reboot to run Pine"

--- a/auto-pine/defaults/stage-1/root/setup/pine_setup.sh
+++ b/auto-pine/defaults/stage-1/root/setup/pine_setup.sh
@@ -115,13 +115,12 @@ echo "*** Stage 8 ***"
 echo
 
 echo \
-[Global]
+"[Global]
 listen = /dev/input/event0
 listen = /dev/input/event1
 
 [Keys]
-ESC = sh /home/pine-user/kill_chrome.sh
-"" \
+ESC = sh /home/pine-user/kill_chrome.sh" \
 | cat > /etc/input-event-daemon.conf
 
 cd /etc/init.d/

--- a/auto-pine/defaults/stage-1/root/setup/pine_setup.sh
+++ b/auto-pine/defaults/stage-1/root/setup/pine_setup.sh
@@ -44,12 +44,6 @@ cd /usr/local/lib/input-event-daemon
 make
 make install
 
-# TODO: Add actual config settings to this file.  This just creates it so
-# input-event-daemon doesn't error out when run.
-echo \
-"" \
-| cat > /etc/input-event-daemon.conf
-
 
 ####### INSTALL CHROMIUM
 echo
@@ -119,6 +113,16 @@ cp /etc/inittab /etc/inittab.original
 echo
 echo "*** Stage 8 ***"
 echo
+
+echo \
+[Global]
+listen = /dev/input/event0
+listen = /dev/input/event1
+
+[Keys]
+ESC = sh /home/pine-user/kill_chrome.sh
+"" \
+| cat > /etc/input-event-daemon.conf
 
 cd /etc/init.d/
 chmod 755 start_pine_daemons.sh


### PR DESCRIPTION
Requesting a code review from @psema4.

This is incomplete, but we'll need it for creating daemons for listening to keys (for redirecting Chromium to the Pine app, for example).  I think this is correct, but perhaps there is a better way to install input-event-daemon.

After this, I need to run input-event-daemon with root permissions at boot time as pine-user.  Do you have any thoughts on how to do that?
